### PR TITLE
Fix wrong path in noise_router/vegetation

### DIFF
--- a/Better_Cave_Worlds/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/Better_Cave_Worlds/data/minecraft/worldgen/noise_settings/overworld.json
@@ -25,7 +25,7 @@
     "fluid_level_spread": "better_cave_worlds:overworld/aquifer/fluid_level_spread",
     "lava": "better_cave_worlds:overworld/aquifer/lava",
     "temperature": "better_cave_worlds:overworld/temperature",
-    "vegetation": "better_cave_worlds:overworld/temperature",
+    "vegetation": "better_cave_worlds:overworld/vegetation",
     "continents": "better_cave_worlds:overworld/continents",
     "erosion": "better_cave_worlds:overworld/erosion",
     "depth": "better_cave_worlds:overworld/depth",


### PR DESCRIPTION
I found this bug when finding village_savanna.

Some biomes are missing due to this wrong noise settings

After fixing the biomes are back in `/locate`